### PR TITLE
Fixed SSH checkbox being checked when SSH is enabled

### DIFF
--- a/js/ui-system-settings.js
+++ b/js/ui-system-settings.js
@@ -199,6 +199,7 @@ window.ui = window.ui || {};
 		systemSettingsView.Alexa.checked = Data.provision.system.allowAlexaDiscovery;
 		systemSettingsView.Bonjour.checked = Data.provision.system.useBonjourService;
 		systemSettingsView.AutomaticUpdates.checked = Data.provision.system.automaticUpdates;
+		systemSettingsView.SSH.checked = Data.provision.system.SSH;
 
 		//TODO Developer mode commented out atm
 		/*


### PR DESCRIPTION
The SSH checkbox on the settings page does not reflect the current status of the SSH functionality. Fixes https://github.com/sprinkler/rainmachine-web-ui/issues/336