### PR TITLE
Weather charts: fix getParserName

### DIFF
--- a/js/ui-charts-parsers.js
+++ b/js/ui-charts-parsers.js
@@ -628,7 +628,7 @@ function getParserName(id) {
 		if (Data.parsers.parsers[i].uid == id) {
 			var name = Data.parsers.parsers[i].name;
 			var lw = name.lastIndexOf(" ");
-            var newName =  name.substring(0, lw); //Don't show "Parser" word in weather parsers
+			var newName =  name.replace(/\s*Parser$/i, ""); // Don't show "Parser" at end of weather service name
 			return newName;
 		}
 	}


### PR DESCRIPTION
Improve the logic for removing "Parser" from the end of weather parser names.

Fixes #383